### PR TITLE
bunch of tokenization related bug-fixes

### DIFF
--- a/community/leaderboard.md
+++ b/community/leaderboard.md
@@ -68,7 +68,7 @@ To implement a new method, refer to our [contributing guide](../docs/contributin
   <tbody>
     <tr>
       <th>Finetuned</th>
-      <td>1.66e-21</td>
+      <td>3.91e-22</td>
       <td>0.6</td>
     </tr>
     <tr>
@@ -119,7 +119,7 @@ To implement a new method, refer to our [contributing guide](../docs/contributin
       <td>0.56</td>
       <td>0.47</td>
       <td>1.0</td>
-      <td>-57.26</td>
+      <td>-57.34</td>
       <td>0.69</td>
     </tr>
     <tr>

--- a/configs/model/Llama-3.1-8B-Instruct.yaml
+++ b/configs/model/Llama-3.1-8B-Instruct.yaml
@@ -12,3 +12,4 @@ template_args:
   user_end_tag: "<|eot_id|>"
   asst_start_tag: "<|start_header_id|>assistant<|end_header_id|>\n\n"
   asst_end_tag: "<|eot_id|>"
+  date_string: 10 Apr 2025

--- a/configs/model/Llama-3.2-1B-Instruct.yaml
+++ b/configs/model/Llama-3.2-1B-Instruct.yaml
@@ -12,3 +12,4 @@ template_args:
   user_end_tag: "<|eot_id|>"
   asst_start_tag: "<|start_header_id|>assistant<|end_header_id|>\n\n"
   asst_end_tag: "<|eot_id|>"
+  date_string: 10 Apr 2025

--- a/configs/model/Llama-3.2-3B-Instruct.yaml
+++ b/configs/model/Llama-3.2-3B-Instruct.yaml
@@ -12,3 +12,4 @@ template_args:
   user_end_tag: "<|eot_id|>"
   asst_start_tag: "<|start_header_id|>assistant<|end_header_id|>\n\n"
   asst_end_tag: "<|eot_id|>"
+  date_string: 10 Apr 2025

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -27,7 +27,7 @@ python src/eval.py --config-name=eval.yaml \
 Run the MUSE-Books benchmark evaluation on a checkpoint of a Phi-3.5 model:
 ```bash
 python src/eval.py --config-name=eval.yaml \
-  experiment=eval/muse/llama2 \
+  experiment=eval/muse/default \
   data_split=Books
   model=Llama-2-7b-hf.yaml \
   model.model_args.pretrained_model_name_or_path=<LOCAL_MODEL_PATH> \

--- a/src/data/utils.py
+++ b/src/data/utils.py
@@ -53,15 +53,17 @@ def preprocess_chat_instance(
         for prompt, response in zip(prompt_msgs, response_msgs):
             chat += [{"role": "user", "content": prompt}]
             chat += [{"role": "assistant", "content": response}]
-        chat_ids = tokenizer.apply_chat_template(
-            chat, tokenize=True, add_generation_prompt=False
+        date_str = template_config.get('date_string', None)
+        date_info = {'date_string': date_str} if date_str is not None else {}
+        chat_ids = tokenizer.apply_chat_texmplate(
+            chat, tokenize=True, add_generation_prompt=False, **date_info
         )
         # all except last response are in-context examples
         wrapped_prompt = tokenizer.apply_chat_template(
-            chat[:-1], tokenize=False, add_generation_prompt=True
+            chat[:-1], tokenize=False, add_generation_prompt=True, **date_info
         )
         prompt_ids = tokenizer.apply_chat_template(
-            chat[:-1], tokenize=True, add_generation_prompt=True
+            chat[:-1], tokenize=True, add_generation_prompt=True, **date_info
         )
     else:
         wrapped_prompt = ""

--- a/src/data/utils.py
+++ b/src/data/utils.py
@@ -6,7 +6,8 @@ from typing import List, Dict, Any, Union
 
 IGNORE_INDEX = -100  # TODO put in common constants
 
-logger = logging.getLogger("data_preprocessor")
+logger = logging.getLogger("data")
+
 
 def load_hf_dataset(path, **kwargs):
     dataset = datasets.load_dataset(path, **kwargs)
@@ -121,15 +122,17 @@ def preprocess_chat_instance(
     else:
         item["input_ids"] = chat_ids
         labels = [IGNORE_INDEX] * len_matched + chat_ids[len_matched:]
-        if len(prompt_ids)==len(chat_ids):
+        if len(prompt_ids) == len(chat_ids):
             # Rarely, tokenization can result in this condition being entered.
             # Say a input prompt is ABC and target output is D, tokenizer(ABCD)
-            # can be [AB, CD] and tokenizer(ABC) can be [AB, C]. In this case, 
-            # we ignore loss on all indices in the labels. So, there is no way 
-            # to use this for next token prediction. Be careful while 
+            # can be [AB, CD] and tokenizer(ABC) can be [AB, C]. In this case,
+            # we ignore loss on all indices in the labels. So, there is no way
+            # to use this for next token prediction. Be careful while
             # interpreting results of such instances.
-            logger.warning("Tokenization mismatch: no valid target tokens for loss computation")
-            
+            logger.warning(
+                "Tokenization mismatch: no valid target tokens for loss computation"
+            )
+
     item["labels"] = labels
     item["attention_mask"] = [1] * len(item["input_ids"])
     for attr in item:

--- a/src/data/utils.py
+++ b/src/data/utils.py
@@ -55,7 +55,7 @@ def preprocess_chat_instance(
             chat += [{"role": "assistant", "content": response}]
         date_str = template_config.get("date_string", None)
         date_info = {"date_string": date_str} if date_str is not None else {}
-        chat_ids = tokenizer.apply_chat_texmplate(
+        chat_ids = tokenizer.apply_chat_template(
             chat, tokenize=True, add_generation_prompt=False, **date_info
         )
         # all except last response are in-context examples

--- a/src/data/utils.py
+++ b/src/data/utils.py
@@ -53,8 +53,8 @@ def preprocess_chat_instance(
         for prompt, response in zip(prompt_msgs, response_msgs):
             chat += [{"role": "user", "content": prompt}]
             chat += [{"role": "assistant", "content": response}]
-        date_str = template_config.get('date_string', None)
-        date_info = {'date_string': date_str} if date_str is not None else {}
+        date_str = template_config.get("date_string", None)
+        date_info = {"date_string": date_str} if date_str is not None else {}
         chat_ids = tokenizer.apply_chat_texmplate(
             chat, tokenize=True, add_generation_prompt=False, **date_info
         )

--- a/src/evals/metrics/memorization.py
+++ b/src/evals/metrics/memorization.py
@@ -52,8 +52,8 @@ def probability_w_options(model, **kwargs):
     filtered_indices = [idx for idx in correct_indices 
                        if correct_answer_results[idx] is not None 
                        and wrong_answer_results[idx] is not None]
-    correct = np.array([correct_answer_results[idx] for idx in filtered_indices])
-    all_wrong = np.array([correct_answer_results[idx] for idx in filtered_indices])
+    correct = np.array([correct_answer_results[idx]["prob"] for idx in filtered_indices])
+    all_wrong = np.array([wrong_answer_results[idx]["prob"] for idx in filtered_indices])
     wrong = np.sum(all_wrong, axis=tuple(range(1, all_wrong.ndim)))
     probs = correct / (correct + wrong + 1e-10)
 

--- a/src/evals/metrics/memorization.py
+++ b/src/evals/metrics/memorization.py
@@ -32,7 +32,13 @@ def probability(model, **kwargs):
     scores_by_index = run_batchwise_evals(
         model, dataloader, evaluate_probability, fun_args, "Calculating loss"
     )
-    prob_values = np.array([evals["prob"] for evals in scores_by_index.values() if evals['prob'] is not None])
+    prob_values = np.array(
+        [
+            evals["prob"]
+            for evals in scores_by_index.values()
+            if evals["prob"] is not None
+        ]
+    )
     prob_values = aggregate_to_1D(prob_values)
     return {"agg_value": np.mean(prob_values), "value_by_index": scores_by_index}
 
@@ -47,13 +53,20 @@ def probability_w_options(model, **kwargs):
     correct_indices = list(correct_answer_results.keys())
     wrong_indices = list(wrong_answer_results.keys())
     assert correct_indices == wrong_indices
-        
+
     # Filter out None values from both correct and wrong answers
-    filtered_indices = [idx for idx in correct_indices 
-                       if correct_answer_results[idx] is not None 
-                       and wrong_answer_results[idx] is not None]
-    correct = np.array([correct_answer_results[idx]["prob"] for idx in filtered_indices])
-    all_wrong = np.array([wrong_answer_results[idx]["prob"] for idx in filtered_indices])
+    filtered_indices = [
+        idx
+        for idx in correct_indices
+        if correct_answer_results[idx] is not None
+        and wrong_answer_results[idx] is not None
+    ]
+    correct = np.array(
+        [correct_answer_results[idx]["prob"] for idx in filtered_indices]
+    )
+    all_wrong = np.array(
+        [wrong_answer_results[idx]["prob"] for idx in filtered_indices]
+    )
     wrong = np.sum(all_wrong, axis=tuple(range(1, all_wrong.ndim)))
     probs = correct / (correct + wrong + 1e-10)
 
@@ -80,7 +93,11 @@ def rouge(model, **kwargs):
         "Calculating text similarity",
     )
     rouge_values = np.array(
-        [evals[kwargs["rouge_type"]] for evals in scores_by_index.values() if evals[kwargs["rouge_type"]] is not None]
+        [
+            evals[kwargs["rouge_type"]]
+            for evals in scores_by_index.values()
+            if evals[kwargs["rouge_type"]] is not None
+        ]
     )
     rouge_values = aggregate_to_1D(rouge_values)
     return {
@@ -113,19 +130,24 @@ def truth_ratio(model, **kwargs):
 
     correct_answer_results = kwargs["pre_compute"]["correct"]["value_by_index"]
     wrong_answer_results = kwargs["pre_compute"]["wrong"]["value_by_index"]
-    
+
     correct_indices = list(correct_answer_results.keys())
     wrong_indices = list(wrong_answer_results.keys())
     assert correct_indices == wrong_indices
-    
+
     # Filter out None values from both correct and wrong answers
-    filtered_indices = [idx for idx in correct_indices 
-                       if correct_answer_results[idx] is not None 
-                       and wrong_answer_results[idx] is not None]
+    filtered_indices = [
+        idx
+        for idx in correct_indices
+        if correct_answer_results[idx] is not None
+        and wrong_answer_results[idx] is not None
+    ]
     correct_avg_losses = [
         correct_answer_results[idx]["avg_loss"] for idx in filtered_indices
     ]
-    wrong_avg_losses = [wrong_answer_results[idx]["avg_loss"] for idx in filtered_indices]
+    wrong_avg_losses = [
+        wrong_answer_results[idx]["avg_loss"] for idx in filtered_indices
+    ]
 
     correct_avg_losses = aggregate_to_1D(np.array(correct_avg_losses))
     wrong_avg_losses = aggregate_to_1D(np.array(wrong_avg_losses))
@@ -182,7 +204,13 @@ def exact_memorization(model, **kwargs):
     scores_by_index = run_batchwise_evals(
         model, dataloader, _exact_memorization, fun_args, "Calculating EM"
     )
-    em_values = np.array([evals["score"] for evals in scores_by_index.values() if evals['score'] is not None])
+    em_values = np.array(
+        [
+            evals["score"]
+            for evals in scores_by_index.values()
+            if evals["score"] is not None
+        ]
+    )
     em_values = aggregate_to_1D(em_values)
     return {"agg_value": np.mean(em_values), "value_by_index": scores_by_index}
 
@@ -226,6 +254,12 @@ def extraction_strength(model, **kwargs):
     scores_by_index = run_batchwise_evals(
         model, dataloader, _extraction_strength, fun_args, "Calculating ES"
     )
-    es_values = np.array([evals["score"] for evals in scores_by_index.values() if evals['score'] is not None])
+    es_values = np.array(
+        [
+            evals["score"]
+            for evals in scores_by_index.values()
+            if evals["score"] is not None
+        ]
+    )
     es_values = aggregate_to_1D(es_values)
     return {"agg_value": np.mean(es_values), "value_by_index": scores_by_index}

--- a/src/evals/metrics/memorization.py
+++ b/src/evals/metrics/memorization.py
@@ -157,9 +157,9 @@ def exact_memorization(model, **kwargs):
             assert len(log_probs) == len(labels)
             valid_len = len(labels)
             if valid_len == 0:
-                # Rarely, tokenization can result in a mismatch with no valid target 
-                # tokens for loss computation (see preprocess_chat_instance() for 
-                # reference). Since this condition makes no sense in terms of 
+                # Rarely, tokenization can result in a mismatch with no valid target
+                # tokens for loss computation (see preprocess_chat_instance() for
+                # reference). Since this condition makes no sense in terms of
                 # computing EM, we just choose to set EM=0
                 logger.warning(
                     "EM score for an instance is specifically marked 0 without "
@@ -204,9 +204,9 @@ def extraction_strength(model, **kwargs):
                 if torch.equal(suff_preds, suff_labels):
                     break
             if valid_len == 0:
-                # Rarely, tokenization can result in a mismatch with no valid target 
-                # tokens for loss computation (see preprocess_chat_instance() for 
-                # reference). Since this condition makes no sense in terms of 
+                # Rarely, tokenization can result in a mismatch with no valid target
+                # tokens for loss computation (see preprocess_chat_instance() for
+                # reference). Since this condition makes no sense in terms of
                 # computing ES, we just choose to set ES=0
                 logger.warning(
                     "ES score for an instance is specifically marked 0 without "

--- a/src/evals/metrics/memorization.py
+++ b/src/evals/metrics/memorization.py
@@ -154,7 +154,6 @@ def exact_memorization(model, **kwargs):
         )
         em_batch = []
         for log_probs, labels in zip(log_probs_batch, labels_batch):
-            assert len(log_probs) == len(labels)
             valid_len = len(labels)
             if valid_len == 0:
                 # Rarely, tokenization can result in a mismatch with no valid target
@@ -195,7 +194,6 @@ def extraction_strength(model, **kwargs):
         )
         es_batch = []
         for log_probs, labels in zip(log_probs_batch, labels_batch):
-            assert len(log_probs) == len(labels)
             valid_len = len(labels)
             preds = torch.argmax(log_probs, dim=-1)
             for k in range(valid_len):

--- a/src/evals/metrics/memorization.py
+++ b/src/evals/metrics/memorization.py
@@ -32,7 +32,7 @@ def probability(model, **kwargs):
     scores_by_index = run_batchwise_evals(
         model, dataloader, evaluate_probability, fun_args, "Calculating loss"
     )
-    prob_values = np.array([evals["prob"] for evals in scores_by_index.values()])
+    prob_values = np.array([evals["prob"] for evals in scores_by_index.values() if evals['prob'] is not None])
     prob_values = aggregate_to_1D(prob_values)
     return {"agg_value": np.mean(prob_values), "value_by_index": scores_by_index}
 
@@ -42,18 +42,19 @@ def probability_w_options(model, **kwargs):
     """Normalize probabilities of correct answers against false answers for
     open-ended datasets, returning the aggregated value and per-index probabilities."""
     correct_answer_results = kwargs["pre_compute"]["correct"]["value_by_index"]
-    wrong_answers_results = kwargs["pre_compute"]["wrong"]["value_by_index"]
+    wrong_answer_results = kwargs["pre_compute"]["wrong"]["value_by_index"]
 
     correct_indices = list(correct_answer_results.keys())
-    wrong_indices = list(wrong_answers_results.keys())
+    wrong_indices = list(wrong_answer_results.keys())
     assert correct_indices == wrong_indices
-    correct = [evals["prob"] for evals in correct_answer_results.values()]
-    all_wrong = [evals["prob"] for evals in wrong_answers_results.values()]
-
-    correct = np.array(correct)
-    all_wrong = np.array(all_wrong)
+        
+    # Filter out None values from both correct and wrong answers
+    filtered_indices = [idx for idx in correct_indices 
+                       if correct_answer_results[idx] is not None 
+                       and wrong_answer_results[idx] is not None]
+    correct = np.array([correct_answer_results[idx] for idx in filtered_indices])
+    all_wrong = np.array([correct_answer_results[idx] for idx in filtered_indices])
     wrong = np.sum(all_wrong, axis=tuple(range(1, all_wrong.ndim)))
-
     probs = correct / (correct + wrong + 1e-10)
 
     value_by_index = dict(zip(correct_indices, [{"prob": val} for val in probs]))
@@ -79,7 +80,7 @@ def rouge(model, **kwargs):
         "Calculating text similarity",
     )
     rouge_values = np.array(
-        [evals[kwargs["rouge_type"]] for evals in scores_by_index.values()]
+        [evals[kwargs["rouge_type"]] for evals in scores_by_index.values() if evals[kwargs["rouge_type"]] is not None]
     )
     rouge_values = aggregate_to_1D(rouge_values)
     return {
@@ -111,15 +112,21 @@ def truth_ratio(model, **kwargs):
         raise ValueError(f"Invalid truth ratio aggregator: {kwargs['aggregator']}")
 
     correct_answer_results = kwargs["pre_compute"]["correct"]["value_by_index"]
-    correct_indices = list(correct_answer_results.keys())
-    correct_avg_losses = [
-        evals["avg_loss"] for evals in correct_answer_results.values()
-    ]
     wrong_answer_results = kwargs["pre_compute"]["wrong"]["value_by_index"]
+    
+    correct_indices = list(correct_answer_results.keys())
     wrong_indices = list(wrong_answer_results.keys())
-    wrong_avg_losses = [evals["avg_loss"] for evals in wrong_answer_results.values()]
-
     assert correct_indices == wrong_indices
+    
+    # Filter out None values from both correct and wrong answers
+    filtered_indices = [idx for idx in correct_indices 
+                       if correct_answer_results[idx] is not None 
+                       and wrong_answer_results[idx] is not None]
+    correct_avg_losses = [
+        correct_answer_results[idx]["avg_loss"] for idx in filtered_indices
+    ]
+    wrong_avg_losses = [wrong_answer_results[idx]["avg_loss"] for idx in filtered_indices]
+
     correct_avg_losses = aggregate_to_1D(np.array(correct_avg_losses))
     wrong_avg_losses = aggregate_to_1D(np.array(wrong_avg_losses))
 
@@ -159,13 +166,12 @@ def exact_memorization(model, **kwargs):
                 # Rarely, tokenization can result in a mismatch with no valid target
                 # tokens for loss computation (see preprocess_chat_instance() for
                 # reference). Since this condition makes no sense in terms of
-                # computing EM, we just choose to set EM=0
+                # computing EM, we just choose to set EM=None
                 logger.warning(
-                    "EM score for an instance is specifically marked 0 without "
-                    "computation, due to tokenization issues that resulted in no valid "
-                    "target tokens."
+                    "EM score for an instance is marked None, due to "
+                    "tokenization issues that resulted in no valid target tokens."
                 )
-                em_batch.append({"score": 0})
+                em_batch.append({"score": None})
             else:
                 preds = torch.argmax(log_probs, dim=-1)
                 em_score = (preds == labels).sum() / valid_len
@@ -176,7 +182,7 @@ def exact_memorization(model, **kwargs):
     scores_by_index = run_batchwise_evals(
         model, dataloader, _exact_memorization, fun_args, "Calculating EM"
     )
-    em_values = np.array([evals["score"] for evals in scores_by_index.values()])
+    em_values = np.array([evals["score"] for evals in scores_by_index.values() if evals['score'] is not None])
     em_values = aggregate_to_1D(em_values)
     return {"agg_value": np.mean(em_values), "value_by_index": scores_by_index}
 
@@ -205,11 +211,10 @@ def extraction_strength(model, **kwargs):
                 # Rarely, tokenization can result in a mismatch with no valid target
                 # tokens for loss computation (see preprocess_chat_instance() for
                 # reference). Since this condition makes no sense in terms of
-                # computing ES, we just choose to set ES=0
+                # computing ES, we just choose to set ES=None
                 logger.warning(
-                    "ES score for an instance is specifically marked 0 without "
-                    "computation, due to tokenization issues that resulted in no valid "
-                    "target tokens."
+                    "ES score for an instance is marked None, due to "
+                    "tokenization issues that resulted in no valid target tokens."
                 )
                 es_batch.append({"score": 0})
             else:
@@ -221,6 +226,6 @@ def extraction_strength(model, **kwargs):
     scores_by_index = run_batchwise_evals(
         model, dataloader, _extraction_strength, fun_args, "Calculating ES"
     )
-    es_values = np.array([evals["score"] for evals in scores_by_index.values()])
+    es_values = np.array([evals["score"] for evals in scores_by_index.values() if evals['score'] is not None])
     es_values = aggregate_to_1D(es_values)
     return {"agg_value": np.mean(es_values), "value_by_index": scores_by_index}

--- a/src/evals/metrics/mia/gradnorm.py
+++ b/src/evals/metrics/mia/gradnorm.py
@@ -18,6 +18,7 @@ class GradNormAttack(Attack):
 
     def compute_batch_values(self, batch):
         """Compute gradients of examples w.r.t model parameters. More grad norm => more loss."""
+        self.model.train()
         batch_log_probs = tokenwise_logprobs(self.model, batch, grad=True)
         batch_loss = [-torch.mean(lps) for lps in batch_log_probs]
         batch_grad_norms = []
@@ -29,6 +30,7 @@ class GradNormAttack(Attack):
                 if param.grad is not None:
                     sample_grad_norms.append(param.grad.detach().norm(p=self.p))
             batch_grad_norms.append(torch.stack(sample_grad_norms).mean())
+        self.model.eval()
         return batch_grad_norms
 
     def compute_score(self, sample_stats):

--- a/src/evals/metrics/utils.py
+++ b/src/evals/metrics/utils.py
@@ -131,7 +131,8 @@ def tokenwise_logprobs(model, batch, grad=False, return_labels=False):
         ]  # -1 to ignore eos prediction
         num_actual_tokens = actual_indices.numel()
         if num_actual_tokens == 0:
-            log_probs_batch.append(torch.tensor([0.0], device=labels.device))
+            labels_batch.append(torch.tensor([], device=labels.device))
+            log_probs_batch.append(torch.tensor([], device=labels.device))
             continue
         start_idx, end_idx = actual_indices[0].item(), actual_indices[-1].item()
         if start_idx == 0:
@@ -173,7 +174,8 @@ def tokenwise_vocab_logprobs(model, batch, grad=False, return_labels=False):
             :-1
         ]  # -1 to ignore eos prediction
         if len(actual_indices) == 0:
-            log_probs_batch.append(torch.zeros(1, V, device=labels.device))
+            labels_batch.append(torch.tensor([], device=labels.device))
+            log_probs_batch.append(torch.zeros(0, V, device=labels.device))
             continue
         start_idx, end_idx = actual_indices[0].item(), actual_indices[-1].item()
         if start_idx == 0:

--- a/src/evals/metrics/utils.py
+++ b/src/evals/metrics/utils.py
@@ -126,7 +126,9 @@ def tokenwise_logprobs(model, batch, grad=False, return_labels=False):
     for i in range(bsz):
         labels = batch["labels"][i]
         # only focus on tokens which have loss on them (i.e. used in labels)
-        actual_indices = (labels != IGNORE_INDEX).nonzero(as_tuple=True)[0][:-1] # -1 to ignore eos prediction
+        actual_indices = (labels != IGNORE_INDEX).nonzero(as_tuple=True)[0][
+            :-1
+        ]  # -1 to ignore eos prediction
         num_actual_tokens = actual_indices.numel()
         if num_actual_tokens == 0:
             log_probs_batch.append(torch.tensor([0.0], device=labels.device))
@@ -167,7 +169,9 @@ def tokenwise_vocab_logprobs(model, batch, grad=False, return_labels=False):
     for i in range(bsz):
         labels = batch["labels"][i]
         # Only include positions that have labels
-        actual_indices = (labels != IGNORE_INDEX).nonzero(as_tuple=True)[0][:-1] # -1 to ignore eos prediction
+        actual_indices = (labels != IGNORE_INDEX).nonzero(as_tuple=True)[0][
+            :-1
+        ]  # -1 to ignore eos prediction
         if len(actual_indices) == 0:
             log_probs_batch.append(torch.zeros(1, V, device=labels.device))
             continue

--- a/src/evals/metrics/utils.py
+++ b/src/evals/metrics/utils.py
@@ -112,8 +112,6 @@ def tokenwise_logprobs(model, batch, grad=False, return_labels=False):
     labels_batch (List[Tensor]): List of tensors of length N. Returned only if return_labels is True
     """
     batch = {k: v.to(model.device) for k, v in batch.items()}
-
-    model.train(mode=grad)
     with torch.set_grad_enabled(grad):
         output = model(**batch)
 
@@ -126,9 +124,9 @@ def tokenwise_logprobs(model, batch, grad=False, return_labels=False):
     log_probs_batch = []
     labels_batch = []
     for i in range(bsz):
-        labels = batch["labels"][i][:-1]
+        labels = batch["labels"][i]
         # only focus on tokens which have loss on them (i.e. used in labels)
-        actual_indices = (labels != IGNORE_INDEX).nonzero(as_tuple=True)[0]
+        actual_indices = (labels != IGNORE_INDEX).nonzero(as_tuple=True)[0][:-1] # -1 to ignore eos prediction
         num_actual_tokens = actual_indices.numel()
         if num_actual_tokens == 0:
             log_probs_batch.append(torch.tensor([0.0], device=labels.device))
@@ -154,7 +152,6 @@ def tokenwise_vocab_logprobs(model, batch, grad=False, return_labels=False):
         labels_batch (List[Tensor]): List of tensors of length N. Returned only if return_labels is True
     """
     batch = {k: v.to(model.device) for k, v in batch.items()}
-    model.train(mode=grad)
     with torch.set_grad_enabled(grad):
         output = model(**batch)
 
@@ -168,9 +165,9 @@ def tokenwise_vocab_logprobs(model, batch, grad=False, return_labels=False):
     log_probs_batch = []
     labels_batch = []
     for i in range(bsz):
-        labels = batch["labels"][i][:-1]
+        labels = batch["labels"][i]
         # Only include positions that have labels
-        actual_indices = (labels != IGNORE_INDEX).nonzero(as_tuple=True)[0]
+        actual_indices = (labels != IGNORE_INDEX).nonzero(as_tuple=True)[0][:-1] # -1 to ignore eos prediction
         if len(actual_indices) == 0:
             log_probs_batch.append(torch.zeros(1, V, device=labels.device))
             continue


### PR DESCRIPTION
# What does this PR do?

Resolves several bugs related to narrow tokenization cases. 2, 3, 4 are interlinked issues and 1 is quite close to them as well. 

1. Log-probs
- Previously the `tokenwise_logprobs` and `tokenwise_vocab_logprobs` functions were inadvertently keeping the `eos` token in the label sequence, leading to the model being forced to predict `eos` token in the MIA (minK, minK++, gradnorm) and ES/EM metrics.
- This wasn't much of an issue w TOFU as the chat model predicts `eos` anyways, but still the original intention was to never get `eos` involved in these calculations.
- This became especially an issue with MUSE (which is not a chat model thus doesn't predict `eos`) leading to low ES scores issues (#100)
- This PR fixes the code, the results and existing evals are to be updated accordingly

2. Small target sequences getting mixed up w prompt
- For some models like Phi-1.5 which have weird tokenizers and for data points which have 1 word target labels, you may end up with the target words being tokenized into the prompt
- This PR warns about such cases and modifies ES and EM to set value as `None` in such cases

3. Handing empty label sequence cases
- When the above issue occurred, previously the code did not update both the labels and logprobs list, leading to mismatch and mixup across the batch which then led to failed asserts with Phi-1.5 [pointed out in #100] 
- This PR ensures empty tensors are sent in such cases

4. Date in system prompt
- Llama3.1 inexplicably adds the current date to the chat template prompt, thus making results irreproducible (#88)
- This PR allows for fixing the date for Llama through the model template args

5. Handling invalid values
- When a metric is evaluated to be `None` on a data point, we set the aggregation to filter out such points and only compute on those that have values

6. Misc modifications
- The `tokenwise_logprobs` and `tokenwise_vocab_logprobs` involved changing model train mode. This was better handled in the evaluation metric code itself (used only by `gradnorm` MIA attack).
- Documentation fix to remove non-existent cfg file

Fixes # (issue)
#98
#100

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Have you gone through the contributions [guide](../docs/contributing.md)?
- [x] Are your changes documented? Read documentation guidelines [here](../README.md#-further-documentation).